### PR TITLE
fix: command code actions

### DIFF
--- a/lua/clear-action/utils.lua
+++ b/lua/clear-action/utils.lua
@@ -5,23 +5,18 @@ local function apply_action(action, client, ctx)
     vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
   elseif action.command then
     local command = type(action.command) == "table" and action.command or action
+    local fn = client.commands[command.command] or vim.lsp.commands[command.command]
 
-    if client._exec_cmd then
-      client._exec_cmd(command, ctx)
+    if fn then
+      ctx.client_id = client.id
+      fn(command, ctx)
     else
-      local fn = client.commands[command.command] or vim.lsp.commands[command.command]
-
-      if fn then
-        ctx.client_id = client.id
-        fn(command, ctx)
-      else
-        local params = {
-          command = command.command,
-          arguments = command.arguments,
-          workDoneToken = command.workDoneToken,
-        }
-        client.request("workspace/executeCommand", params, nil, ctx.bufnr)
-      end
+      local params = {
+        command = command.command,
+        arguments = command.arguments,
+        workDoneToken = command.workDoneToken,
+      }
+      client.request("workspace/executeCommand", params, nil, ctx.bufnr)
     end
   end
 end
@@ -44,7 +39,7 @@ end
 
 M.handle_action = function(action, client, context)
   local supports_resolve = client
-      and vim.tbl_get(client.server_capabilities, "codeActionProvider", "resolveProvider")
+    and vim.tbl_get(client.server_capabilities, "codeActionProvider", "resolveProvider")
 
   if not action.edit and supports_resolve then
     client.request("codeAction/resolve", action, function(err, resolved_action)


### PR DESCRIPTION
Fixes #6.
Use the old implementation of command code actions handler for backward compability.