### PR TITLE
fix: Provide commands with context

### DIFF
--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -21,9 +21,8 @@ local function on_code_action_results(results, context, options)
 
     local client = vim.lsp.get_client_by_id(action_tuple[1])
     local action = action_tuple[2]
-    local ctx = { bufnr = context.bufnr }
 
-    utils.handle_action(action, client, ctx)
+    utils.handle_action(action, client, context)
   end
 
   local action_tuples = {}
@@ -84,7 +83,7 @@ local function code_action(options)
   params.context = context
 
   utils.code_action_request_all(bufnr, params, function(results)
-    local ctx = { bufnr = bufnr }
+    local ctx = { bufnr = bufnr, method = "textDocument/codeAction", params = params }
     on_code_action_results(results, ctx, options)
   end)
 end


### PR DESCRIPTION
After a codeAction request, an LSP server can return **edits**, and **commands**.
Commands can lead to additional server requests.

For example, _java LSP server (JDTLS)_, returns the command "_java.action.overrideMethodsPrompt_",
which is implemented by java _LSP config (nvim-jdtls)_.
In order for the user to select the method(s) te be overriden, the lsp-config sends
a second request to the server, to get a list of overridable methods.

Vim default implementation of code actions keeps a context object between the different
requests, but here, the **context object is reset** after the code action results are received.

As a consequence, the LSP-server is not able to handle the second request.
In order to fix the issue, I changed two lines, and let the context object be
kept, and passed to the second command.

I tested it locally : it fixed my issue.