### PR TITLE
fix: only show signs from current buffer & line

### DIFF
--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -69,7 +69,7 @@ local function code_action(options)
     context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
   end
   if not context.diagnostics then
-    context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)
+    context.diagnostics = utils.get_current_line_diagnostics()
   end
 
   local mode = vim.api.nvim_get_mode().mode
@@ -121,7 +121,7 @@ M.quickfix = function(filters)
     },
     filter = function(action)
       local found = false
-      local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+      local diagnostics = utils.get_current_line_diagnostics()
       for diag_code, fix_message in pairs(filters or {}) do
         for _, diagnostic in pairs(diagnostics) do
           if diagnostic.code == diag_code then

--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -58,11 +58,12 @@ end
 
 local function code_action_request()
   local bufnr = vim.api.nvim_get_current_buf()
+  local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
   local params = vim.lsp.util.make_range_params()
 
   params.context = {
     triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Automatic,
-    diagnostics = vim.lsp.diagnostic.get_line_diagnostics(),
+    diagnostics = utils.get_current_line_diagnostics(),
   }
   utils.code_action_request(bufnr, params, on_result)
 end

--- a/lua/clear-action/utils.lua
+++ b/lua/clear-action/utils.lua
@@ -83,4 +83,11 @@ M.range_from_selection = function(bufnr, mode)
   }
 end
 
+M.get_current_line_diagnostics = function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
+
+  return vim.diagnostic.get(bufnr, { lnum = row })
+end
+
 return M


### PR DESCRIPTION
## What?
When fetching the possible code actions for a line we're calling [`vim.lsp.diagnostic.get_line_diagnostics()`](https://github.com/luckasRanarison/clear-action.nvim/blob/e36fad3b9ebb85acdd5c41651b51a3cf70991323/lua/clear-action/signs.lua#L65) inside `code_action_request()`, which will fetch all diagnostics on that specific line number across buffers, and not the current buffer.

### Example
We're on buffer 1, and on line 7. Buffer 2 is in the background, and contains a diagnostic on line 7. We will now get a sign for the diagnostic on line 7 in buffer 1, even though no code actions are available for this specific line.

## Solution
We could just add `bufnr` as an argument like this: ` vim.lsp.diagnostic.get_line_diagnostics(bufnr)`.  

As `get_line_diagnostics` is [deprecated](https://neovim.io/doc/user/deprecated.html#vim.lsp.diagnostic.get_line_diagnostics()), I instead wrote a utility function `utils.get_current_line_diagnostics` which will fetch the correct bufnr and line and call `vim.diagnostic.get`.