### PR TITLE
fix: action kind does not always have value

### DIFF
--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -19,7 +19,7 @@ local function on_result(results, context)
 
     for _, action in pairs(results) do
       for key, value in pairs(actions) do
-        if vim.startswith(action.kind, key) then actions[key] = value + 1 end
+        if action.kind and vim.startswith(action.kind, key) then actions[key] = value + 1 end
       end
     end
     for key, _ in pairs(actions) do


### PR DESCRIPTION
Some servers doesn't provide result for `action.kind`. Fixes #14 

Tested with `taplo` for toml file

<img width="1160" alt="Screenshot 2023-10-24 at 13 38 55" src="https://github.com/luckasRanarison/clear-action.nvim/assets/42694704/c8e33fa2-12e7-4c21-b6c9-4006400a0b6b">
