### PR TITLE
For #22: handle code actions coming in from more than one LSP client.

### DIFF
--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -8,14 +8,16 @@ local clear_extmark = function() vim.api.nvim_buf_clear_namespace(0, config.ns, 
 local function on_result(results_all, line, bufnr)
   local count = 0
   local flat = {}
+
   for client_id, results in pairs(results_all) do
     if results.result ~= nil then
       count = count + #results.result
       for _, action in pairs(results.result) do
-        table.insert(flat, vim.tbl_extend("error", action, {client_id = client_id}))
+        table.insert(flat, vim.tbl_extend("error", action, { client_id = client_id }))
       end
     end
   end
+
   local virt_text = {}
   local opts = config.options.signs
 

--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -6,28 +6,28 @@ local utils = require("clear-action.utils")
 local clear_extmark = function() vim.api.nvim_buf_clear_namespace(0, config.ns, 0, -1) end
 
 local function on_result(results_all, line, bufnr)
-  local result_count = 0
-  local result_actions_flat = {}
+  local count = 0
+  local flat = {}
   for client_id, results in pairs(results_all) do
     if results.result ~= nil then
-      result_count = result_count + #results.result
+      count = count + #results.result
       for _, action in pairs(results.result) do
-        table.insert(result_actions_flat, action)
+        table.insert(flat, action)
       end
     end
   end
   local virt_text = {}
   local opts = config.options.signs
 
-  if opts.combine and result_count > 0 then
+  if opts.combine and count > 0 then
     table.insert(virt_text, {
-      opts.icons.combined .. (opts.show_count and result_count or ""),
+      opts.icons.combined .. (opts.show_count and count or ""),
       opts.highlights.combined,
     })
   else
     local actions = { quickfix = 0, refactor = 0, source = 0, combined = 0 }
 
-    for _, action in pairs(result_actions_flat) do
+    for _, action in pairs(flat) do
       if action.kind then
         for key, value in pairs(actions) do
           if vim.startswith(action.kind, key) then
@@ -49,9 +49,9 @@ local function on_result(results_all, line, bufnr)
     end
   end
 
-  if result_count > 0 and opts.show_label then
+  if count > 0 and opts.show_label then
     table.insert(virt_text, { opts.separator })
-    table.insert(virt_text, { opts.label_fmt(result_actions_flat), opts.highlights.label })
+    table.insert(virt_text, { opts.label_fmt(flat), opts.highlights.label })
   end
 
   local cursor = vim.api.nvim_win_get_cursor(0)

--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -35,7 +35,7 @@ local function on_result(results_all, line, bufnr)
           end
         end
       else
-        actions.combined = actions.combined + 1 -- Shouldn't we not count any actions that have no kind?
+        actions.combined = actions.combined + 1
       end
     end
     for key, _ in pairs(actions) do

--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -12,7 +12,7 @@ local function on_result(results_all, line, bufnr)
     if results.result ~= nil then
       count = count + #results.result
       for _, action in pairs(results.result) do
-        table.insert(flat, action)
+        table.insert(flat, vim.tbl_extend("error", action, {client_id = client_id}))
       end
     end
   end

--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -5,19 +5,29 @@ local utils = require("clear-action.utils")
 
 local clear_extmark = function() vim.api.nvim_buf_clear_namespace(0, config.ns, 0, -1) end
 
-local function on_result(results, context)
+local function on_result(results_all, line, bufnr)
+  local result_count = 0
+  local result_actions_flat = {}
+  for client_id, results in pairs(results_all) do
+    if results.result ~= nil then
+      result_count = result_count + #results.result
+      for _, action in pairs(results.result) do
+        table.insert(result_actions_flat, action)
+      end
+    end
+  end
   local virt_text = {}
   local opts = config.options.signs
 
-  if opts.combine and #results > 0 then
+  if opts.combine and result_count > 0 then
     table.insert(virt_text, {
-      opts.icons.combined .. (opts.show_count and #results or ""),
+      opts.icons.combined .. (opts.show_count and result_count or ""),
       opts.highlights.combined,
     })
   else
     local actions = { quickfix = 0, refactor = 0, source = 0, combined = 0 }
 
-    for _, action in pairs(results) do
+    for _, action in pairs(result_actions_flat) do
       if action.kind then
         for key, value in pairs(actions) do
           if vim.startswith(action.kind, key) then
@@ -25,7 +35,7 @@ local function on_result(results, context)
           end
         end
       else
-        actions.combined = actions.combined + 1
+        actions.combined = actions.combined + 1 -- Shouldn't we not count any actions that have no kind?
       end
     end
     for key, _ in pairs(actions) do
@@ -39,21 +49,20 @@ local function on_result(results, context)
     end
   end
 
-  if #results > 0 and opts.show_label then
+  if result_count > 0 and opts.show_label then
     table.insert(virt_text, { opts.separator })
-    table.insert(virt_text, { opts.label_fmt(results), opts.highlights.label })
+    table.insert(virt_text, { opts.label_fmt(result_actions_flat), opts.highlights.label })
   end
 
   local cursor = vim.api.nvim_win_get_cursor(0)
   local col = opts.position == "overlay" and (cursor[2] + 1) or 0
-  local context_line = context.params.range.start.line
   local is_insert = vim.fn.mode() == "i"
   local update = opts.update_on_insert == is_insert
 
   clear_extmark()
 
-  if context_line == cursor[1] - 1 and update then
-    vim.api.nvim_buf_set_extmark(context.bufnr, config.ns, context_line, col, {
+  if line == cursor[1] - 1 and update then
+    vim.api.nvim_buf_set_extmark(bufnr, config.ns, line, col, {
       hl_mode = "combine",
       virt_text = virt_text,
       virt_text_pos = opts.position,
@@ -70,7 +79,7 @@ local function code_action_request()
     triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Automatic,
     diagnostics = utils.get_current_line_diagnostics(),
   }
-  utils.code_action_request(bufnr, params, on_result)
+  utils.code_action_request_all(bufnr, params, on_result)
 end
 
 local function update()

--- a/lua/clear-action/utils.lua
+++ b/lua/clear-action/utils.lua
@@ -35,7 +35,7 @@ end
 
 M.code_action_request_all = function(bufnr, params, on_result)
   vim.lsp.buf_request_all(bufnr, "textDocument/codeAction", params, function(results)
-    if results then on_result(results) end
+    if results then on_result(results, params.range.start.line, bufnr) end
   end)
 end
 


### PR DESCRIPTION
Resolves #22 

~I'm not sure why it makes one group in the `virt_text` for each client.~ OK this is why: both combined and refactor use lightbulb and during my testing with lua_ls and null_ls, lua_ls gives nothing for "kind", while null_ls gives "refactor" ones, this creates two category groups reported, refactor and combined, so this appears to be the code working correctly.

I did not expect this code to already work in this state. But I am frazzled from trying to grok all of the code that I do not yet understand. Please provide some feedback. 