### PR TITLE
Fix running update() as often as there are LSPs accepting code action requests attached on the buffer

### DIFF
--- a/lua/clear-action/signs.lua
+++ b/lua/clear-action/signs.lua
@@ -91,11 +91,15 @@ M.on_attach = function(bufnr)
     })
   end
 
+  if vim.b[bufnr].is_update_autocmd_set then
+    return
+  end
   vim.api.nvim_create_autocmd(events, {
     buffer = bufnr,
     group = config.augroup,
     callback = update,
   })
+  vim.b[bufnr].is_update_autocmd_set = true
 end
 
 M.toggle_signs = function()


### PR DESCRIPTION
Adding buffer local variable assignment and check to prevent the installation of more than one `update()` autocmd.