### PR TITLE
Add display of lsp client name to codeaction labels popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The default configuration:
     center = false,
     border = "rounded",
     hide_cursor = false,
+    hide_client = false, -- hide displaying name of LSP client
     highlights = {
       header = "CodeActionHeader",
       label = "CodeActionLabel",

--- a/lua/clear-action/config.lua
+++ b/lua/clear-action/config.lua
@@ -36,6 +36,7 @@ local defaults = {
       header = "CodeActionHeader",
       label = "CodeActionLabel",
       title = "CodeActionTitle",
+      lsp = "Comment",
     },
   },
   mappings = {

--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -32,7 +32,7 @@ local function lsp_client_display_name(client_id)
   local client = vim.lsp.get_client_by_id(client_id)
   log(client_id, client)
   if client then
-    return " (" .. client.name .. ")"
+    return " " .. client.name
   else
     return ""
   end
@@ -90,9 +90,12 @@ local function fill_popup(bufnr, action_tuples, labels)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
   vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.header, 0, 0, -1)
 
+  log('at', action_tuples)
   for i = 1, #action_tuples do
     vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.label, i, 0, 1)
-    vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.title, i, 2, -1)
+    local len = #action_tuples[i][2].title
+    vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.title, i, 2, len + 2)
+    vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.lsp, i, len + 2, -1)
   end
 
   vim.bo[bufnr].modifiable = false

--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -28,11 +28,22 @@ M.hide_cursor_autocmd = function()
   })
 end
 
+local function lsp_client_display_name(client_id)
+  local client = vim.lsp.get_client_by_id(client_id)
+  log(client_id, client)
+  if client then
+    return " (" .. client.name .. ")"
+  else
+    return ""
+  end
+end
+
 local function create_popup(action_tuples)
   local opts = config.options.popup
   local max_len = 0
   for _, value in pairs(action_tuples) do
-    local len = #value[2].title
+    local final_string = value[2].title .. lsp_client_display_name(value[1])
+    local len = #final_string
     if max_len < len then max_len = len end
   end
   local width = max_len + 5
@@ -72,7 +83,7 @@ local function fill_popup(bufnr, action_tuples, labels)
 
   local lines = vim.tbl_map(function(value)
     local title = value[2].title
-    return labels[title] .. " " .. title
+    return labels[title] .. " " .. title .. lsp_client_display_name(value[1])
   end, action_tuples)
 
   table.insert(lines, 1, "Code actions:")

--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -43,7 +43,7 @@ local function create_popup(action_tuples)
     end
     if max_len < len then max_len = len end
   end
-  local width = max_len + 5
+  local width = max_len + 6
   local height = #action_tuples + 1
   local row, col, position
 

--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -30,11 +30,7 @@ end
 
 local function client_name(client_id)
   local client = vim.lsp.get_client_by_id(client_id)
-  if client then
-    return " " .. client.name
-  else
-    return ""
-  end
+  return client and client.name or ""
 end
 
 local function create_popup(action_tuples)
@@ -86,7 +82,7 @@ local function fill_popup(bufnr, action_tuples, labels)
     local title = value[2].title
     local row = labels[title] .. " " .. title
     if not config.options.popup.hide_client then
-      row = row .. client_name(value[1])
+      row = row .. " " .. client_name(value[1])
     end
     return row
   end, action_tuples)
@@ -95,9 +91,9 @@ local function fill_popup(bufnr, action_tuples, labels)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
   vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.header, 0, 0, -1)
 
-  for i = 1, #action_tuples do
+  for i, action_tuple in ipairs(action_tuples) do
     vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.label, i, 0, 1)
-    local len = #action_tuples[i][2].title
+    local len = #action_tuple[2].title
     vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.title, i, 2, len + 2)
     vim.api.nvim_buf_add_highlight(bufnr, config.ns_popup, opts.highlights.lsp, i, len + 2, -1)
   end


### PR DESCRIPTION
This provides an impl for #25 

I still would like to add 

- replace parentheses with a new highlight group for it
- configuration option to not display this (under typical usage with a single lsp we never want this info after all)