### PR TITLE
feat: allow defining labels for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ The default configuration:
     --   ["unused-local"] = "Disable diagnostics on this line",
     -- },
   },
+  action_labels = {
+    -- example:
+    -- ["dartls"] = {
+    --   "Wrap with widget..." = "w",
+    --   "Wrap with Padding" = "p",
+    --   "Wrap with Center" = "c",
+    -- },
+  },
 }
 ```
 

--- a/lua/clear-action/config.lua
+++ b/lua/clear-action/config.lua
@@ -53,6 +53,7 @@ local defaults = {
     actions = {},
   },
   quickfix_filters = {},
+  action_labels = {},
 }
 
 ---@type clear-action.options

--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -109,10 +109,18 @@ local function create_labels(action_tuples)
   for _, value in pairs(action_tuples) do
     local title = value[2].title
     local first_letter = title:sub(1, 1):lower()
+    local client = client_name(value[1])
 
-    if not used[first_letter] then
-      used[first_letter] = true
-      labels[title] = first_letter
+    local user_defined = config.options.action_labels[client][title]
+
+    if user_defined then
+      used[user_defined] = true
+      labels[title] = user_defined
+    else
+      if not used[first_letter] then
+        used[first_letter] = true
+        labels[title] = first_letter
+      end
     end
   end
   for _, value in pairs(action_tuples) do


### PR DESCRIPTION
Make it possible to define custom labels for selected actions

Before and after:

<img width="2054" alt="Group 2" src="https://github.com/luckasRanarison/clear-action.nvim/assets/15970653/7734e008-ca59-420e-95d8-fa4b66c191b8">
