### PR TITLE
fix: nil access in case action_labels doesn't have the client

### DIFF
--- a/lua/clear-action/popup.lua
+++ b/lua/clear-action/popup.lua
@@ -111,7 +111,7 @@ local function create_labels(action_tuples)
     local first_letter = title:sub(1, 1):lower()
     local client = client_name(value[1])
 
-    local user_defined = config.options.action_labels[client][title]
+    local user_defined = (config.options.action_labels[client] or {})[title]
 
     if user_defined then
       used[user_defined] = true


### PR DESCRIPTION
Following up https://github.com/luckasRanarison/clear-action.nvim/commit/4c28ab096d855df8ed00d77b6f22ea85995bf20f, if the user doesn't define anything for `action_labels[client]`, this turns out to be `ni` and can't access `title`.