### PR TITLE
fix: update prev diagnostic call

### DIFF
--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -147,7 +147,7 @@ end
 
 ---@param filters table<string, string> | nil
 M.quickfix_prev = function(filters)
-  vim.diagnostic.get_prev()
+  vim.diagnostic.goto_prev()
   M.quickfix(filters)
 end
 


### PR DESCRIPTION
this got changed I guess? https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.goto_prev()