### PR TITLE
fix: use vim.islist if available instead of deprecated vim.tbl_islist

### DIFF
--- a/lua/clear-action/mappings.lua
+++ b/lua/clear-action/mappings.lua
@@ -3,8 +3,10 @@ local M = {}
 local config = require("clear-action.config")
 local actions = require("clear-action.actions")
 
+local islist = vim.fn.has("nvim-0.10") and vim.islist or vim.tbl_islist
+
 local function parse_value(value)
-  if type(value) == "table" and not vim.tbl_islist(value) then return value end
+  if type(value) == "table" and not islist(value) then return value end
 
   local opts = {
     options = {},


### PR DESCRIPTION
`vim.tbl_islist` is deprecated starting from nvim 0.10.