### PR TITLE
fix: use nvim 0.10 code action format to `vim.ui.select` if nvim 0.10 or later

### DIFF
--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -34,7 +34,7 @@ local function on_code_action_results(results, context, options)
         action.title = action.title:gsub("\n", "\\n")
 
         local action_tuple
-        if vim.version() >= vim.version.parse("0.10.0") then
+        if not config.options.popup.enable and vim.version() >= vim.version.parse("0.10.0") then
           tuple = { ctx = { client_id = client_id }, action = { title = action.title } }
         else
           tuple = { client_id, action }

--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -32,7 +32,15 @@ local function on_code_action_results(results, context, options)
       if action_filter(action) then
         action.title = action.title:gsub("\r\n", "\\r\\n")
         action.title = action.title:gsub("\n", "\\n")
-        table.insert(action_tuples, { client_id, action })
+
+        local action_tuple
+        if vim.version() >= vim.version.parse("0.10.0") then
+          tuple = { ctx = { client_id = client_id }, action = { title = action.title } }
+        else
+          tuple = { client_id, action }
+        end
+
+        table.insert(action_tuples, tuple)
       end
     end
   end
@@ -52,7 +60,11 @@ local function on_code_action_results(results, context, options)
         prompt = "Code actions:",
         kind = "codeaction",
         format_item = function(action_tuple)
-          return action_tuple[2].title
+          if vim.version() >= vim.version.parse("0.10.0") then
+            return action_tuple.action.title
+          else
+            return action_tuple[2].title
+          end
         end,
       }, on_select)
     end

--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -19,9 +19,16 @@ local function on_code_action_results(results, context, options)
   local function on_select(action_tuple)
     if not action_tuple then return end
 
-    local client = vim.lsp.get_client_by_id(action_tuple[1])
-    local action = action_tuple[2]
+    local client_id, action
+    if vim.version() >= vim.version.parse("0.10.0") then
+      client_id = action_tuple.ctx.client_id
+      action = action_tuple.ctx.action
+    else
+      client_id = action_tuple[1]
+      action = action_tuple[2]
+    end
 
+    local client = vim.lsp.get_client_by_id(client_id)
     utils.handle_action(action, client, context)
   end
 
@@ -35,7 +42,7 @@ local function on_code_action_results(results, context, options)
 
         local action_tuple
         if not config.options.popup.enable and vim.version() >= vim.version.parse("0.10.0") then
-          tuple = { ctx = { client_id = client_id }, action = { title = action.title } }
+          tuple = { ctx = { client_id = client_id }, action = action }
         else
           tuple = { client_id, action }
         end
@@ -83,9 +90,7 @@ local function code_action(options)
   if not context.triggerKind then
     context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
   end
-  if not context.diagnostics then
-    context.diagnostics = utils.get_current_line_diagnostics()
-  end
+  if not context.diagnostics then context.diagnostics = utils.get_current_line_diagnostics() end
 
   local mode = vim.api.nvim_get_mode().mode
   if options.range then

--- a/lua/clear-action/actions.lua
+++ b/lua/clear-action/actions.lua
@@ -22,7 +22,7 @@ local function on_code_action_results(results, context, options)
     local client_id, action
     if vim.version() >= vim.version.parse("0.10.0") then
       client_id = action_tuple.ctx.client_id
-      action = action_tuple.ctx.action
+      action = action_tuple.action
     else
       client_id = action_tuple[1]
       action = action_tuple[2]


### PR DESCRIPTION
This fixes code action options given to `vim.ui.select` to match the format given by nvim 0.10 (when popup is disabled and using nvim 0.10 or later)

This is important, because if you use other plugins such as `telescope-ui-select` that override `vim.ui.select`, they will fail because of the incorrect format.